### PR TITLE
04. abtract repository

### DIFF
--- a/libs/common/src/config/config.module.ts
+++ b/libs/common/src/config/config.module.ts
@@ -11,7 +11,6 @@ import * as Joi from 'joi';
       validationSchema: Joi.object({
         MONGODB_URI: Joi.string(),
       }),
-      isGlobal: true,
     }),
   ],
   providers: [ConfigService],

--- a/libs/common/src/database/abstract.repository.ts
+++ b/libs/common/src/database/abstract.repository.ts
@@ -1,0 +1,61 @@
+import { AbstractDocument } from '@app/common/database/abstract.schema';
+import { FilterQuery, Model, Types, UpdateQuery } from 'mongoose';
+import { Logger, NotFoundException } from '@nestjs/common';
+
+export abstract class AbstractRepository<TDocument extends AbstractDocument> {
+  protected abstract readonly logger: Logger;
+
+  protected constructor(protected readonly model: Model<TDocument>) {}
+
+  async create(document: Omit<TDocument, '_id'>): Promise<TDocument> {
+    const result = new this.model({
+      ...document,
+      _id: new Types.ObjectId(),
+    });
+
+    // [TODO]
+    // - (원래) return (await createdDocument.save()).toJSON() as unknown as TDocument;
+    // - (await createdDocument.save()) as TDocument;
+    // - toJSON()은 제거 해도 되지 않을까?
+    return (await result.save()).toJSON() as TDocument;
+  }
+
+  async findOne(filterQuery: FilterQuery<TDocument>): Promise<TDocument> {
+    const result = await this.model.findOne(filterQuery).lean<TDocument>(true);
+
+    if (!result) {
+      this.logger.warn('Document not found with filterQuery', filterQuery);
+      throw new NotFoundException('Document was not found');
+    }
+
+    return result;
+  }
+
+  async findOneAndUpdate(
+    filterQuery: FilterQuery<TDocument>,
+    update: UpdateQuery<TDocument>,
+  ): Promise<TDocument> {
+    const result = await this.model
+      .findOneAndUpdate(filterQuery, update, {
+        new: true,
+      })
+      .lean<TDocument>(true);
+
+    if (!result) {
+      this.logger.warn('Document not found with filterQuery', filterQuery);
+      throw new NotFoundException('Document was not found');
+    }
+
+    return result;
+  }
+
+  async find(filterQuery: FilterQuery<TDocument>): Promise<TDocument[]> {
+    return this.model.find(filterQuery).lean<TDocument[]>(true);
+  }
+
+  async findOneAndDelete(
+    filterQuery: FilterQuery<TDocument>,
+  ): Promise<TDocument> {
+    return this.model.findOneAndDelete(filterQuery).lean<TDocument>(true);
+  }
+}

--- a/libs/common/src/database/abstract.schema.ts
+++ b/libs/common/src/database/abstract.schema.ts
@@ -1,0 +1,8 @@
+import { Prop, Schema } from '@nestjs/mongoose';
+import { SchemaTypes, Types } from 'mongoose';
+
+@Schema()
+export class AbstractDocument {
+  @Prop({ type: SchemaTypes.ObjectId })
+  _id: Types.ObjectId;
+}


### PR DESCRIPTION
Mongoose는 저장한 후 혹은 조회할 때 Mongoose에서 정의된 #`[class Document](https://mongoosejs.com/docs/documents.html)`로 가져온다.

이에 따라 `TDocument` application에서 정의한 Schema로 가져오는 타입 선언이 필요하다.